### PR TITLE
use the proper xdg cache path for the order file instead of config path, since it's a temporary file

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -243,7 +243,7 @@ view_db=$XDG_DATA_HOME/aurutils/view
 mkdir -p "$view_db"
 
 # Default to showing PKGBUILD first in patch. (#399)
-orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
+orderfile=$XDG_CACHE_HOME/aurutils/$argv0/orderfile
 mkdir -p "${orderfile%/*}"
 
 if [[ ! -s $orderfile ]]; then


### PR DESCRIPTION
use the proper xdg cache path for the order file instead of config path, since it's a temporary file