### PR TITLE
`sync`: run `aur-chroot` before `aur-repo-filter`

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -12,7 +12,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 unset -v CDPATH
 
 # default options
-chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 truncate=1
+chroot=0 no_sync=0 overwrite=0 sign_pkg=0 run_pkgver=0 truncate=1 create_chroot=1
 
 # default arguments (empty)
 chroot_args=() pacconf_args=() repo_args=() repo_add_args=() pkglist_args=()
@@ -100,9 +100,9 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'rmdeps' 'no-confirm' 'no-check' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
-          'margs:' 'buildscript:' 'null')
+          'margs:' 'buildscript:' 'null' 'no-create')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
-            'results:' 'results-append:')
+            'results:' 'results-append:' 'nocreate')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
     eval set -- "$opts"
@@ -155,6 +155,8 @@ while true; do
             makechrootpkg_args+=(-T) ;;
         -U|--user)
             shift; makechrootpkg_args+=(-U "$1") ;;
+        --nocreate|--no-create)
+            create_chroot=0 ;;
         # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             makepkg_common_args+=(--ignorearch)
@@ -338,7 +340,7 @@ if [[ -v results_file ]]; then
     (( truncate )) && true | tee "$results_file"
 fi
 
-if (( chroot )); then
+if (( chroot )) && (( create_chroot )); then
     # Update pacman and makepkg configuration for the chroot build
     # queue. A full system upgrade is run on the /root container to
     # avoid lenghty upgrades for makechrootpkg -u.

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -14,7 +14,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 unset -v CDPATH
 
 # default arguments
-build_args=(--clean --syncdeps)
+build_args=(--clean --syncdeps) chroot_args=()
 depends_args=() repo_args=() view_args=() filter_args=() fetch_args=() graph_args=()
 
 # default options
@@ -209,12 +209,6 @@ while true; do
             build_args+=(--force) ;;
         --makepkg-args|--margs)
             shift; build_args+=(--margs "$1") ;;
-        --makepkg-conf)
-            shift; build_args+=(--makepkg-conf "$1") ;;
-        --pacman-conf)
-            shift; build_args+=(--pacman-conf "$1")
-            repo_args+=(--config "$1")
-            filter_args+=(--config "$1") ;;
         --pkgver)
             build_args+=(--pkgver) ;;
         -S|--sign|--gpg-sign)
@@ -222,12 +216,20 @@ while true; do
         -U|--user)
             shift; build_args+=(--user "$1") ;;
         # build options (devtools)
+        --makepkg-conf)
+            shift; build_args+=(--makepkg-conf "$1")
+            chroot_args+=(--makepkg-conf "$1") ;;
+        --pacman-conf)
+            shift; build_args+=(--pacman-conf "$1")
+            chroot_args+=(--pacman-conf "$1")
+            filter_args+=(--config "$1")
+            repo_args+=(--config "$1") ;;
         -D|--directory)
-            shift; build_args+=(--directory "$1") ;;
+            shift; chroot_args+=(--directory "$1") ;;
         --bind)
-            shift; build_args+=(--bind "$1") ;;
+            shift; chroot_args+=(--bind "$1") ;;
         --bind-rw)
-            shift; build_args+=(--bind-rw "$1") ;;
+            shift; chroot_args+=(--bind-rw "$1") ;;
         -T|--temp)
             build_args+=(-T) ;;
         # build options (makepkg)
@@ -483,7 +485,7 @@ elif (( AUR_SYNC_USE_NINJA )); then
     # input:  $AURDEST/pkgbase/PKGBUILD
     # output: $ninja_dir/pkgbase.stamp
     aur sync--ninja "$AURDEST" <"$tmp"/graph.ninja >"$ninja_dir"/build.ninja \
-        -- aur build "${build_args[@]}" -d "$db_name" --root "$db_root"
+        -- aur build "${build_args[@]}" "${chroot_args[@]}" -d "$db_name" --root "$db_root"
 
     if NINJA_STATUS='[%s/%t] ' ninja -C "$ninja_dir" -k "$keep_going"; then
         # Remove ninja directory on successful build
@@ -510,7 +512,7 @@ else
     if [[ -v stdout_file ]]; then
         cat "$tmp"/queue.realpath >"$stdout_file"
     fi
-    aur build "${build_args[@]}" -a "$tmp"/queue.realpath -d "$db_name" --root "$db_root"
+    aur build "${build_args[@]}" "${chroot_args[@]}" -a "$tmp"/queue.realpath -d "$db_name" --root "$db_root"
 fi
 
 # vim: set et sw=4 sts=4 ft=sh:

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -18,7 +18,7 @@ build_args=(--clean --syncdeps) chroot_args=()
 depends_args=() repo_args=() view_args=() filter_args=() fetch_args=() graph_args=()
 
 # default options
-build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1
+build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1 chroot=0
 
 # default options (disabled)
 rotate=0 update=0 repo_targets=0 columns=0
@@ -204,7 +204,7 @@ while true; do
             view_args+=(--prefix) ;;  # experimental
         # build options
         -c|--chroot)
-            build_args+=(--chroot) ;;
+            chroot=1; build_args+=(--chroot) ;;
         -f|--force)
             build_args+=(--force) ;;
         --makepkg-args|--margs)
@@ -357,6 +357,19 @@ fi
 
 # pkginfo: $1 pkgname $2 pkgbase $3 pkgver
 cut -f2,5 --complement "$tmp"/depends | sort -u >"$tmp"/pkginfo
+
+if (( chroot )); then
+    chroot_path=$(aur chroot "${chroot_args[@]}" --create --update --path)
+
+    # Skip default creation/update is in later `aur-build` calls. This is also
+    # relevant to `AUR_SYNC_USE_NINJA=1` with one `aur-build` call per package.
+    build_args+=(--no-create)
+
+    # `pacman` state may differ between host and containers. To ensure
+    # accurate results for `makepkg`, use the container location as
+    # pacutils-sysroot(7) for `aur-repo-filter`.
+    filter_args+=(--sysroot "$chroot_path")
+fi
 
 { cat "$tmp"/igni # ignored packages (already included by aur-depends --assume-installed)
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -5,6 +5,10 @@
 
 * `aur-build`
   + shell escape file names in diagnostics
+  + add `--no-create`
+
+* `aur-sync`
+  + run `aur-chroot` before `aur-repo-filter` (#1042)
 
 ## 17.3
 


### PR DESCRIPTION
Issue #1042

Note: this approach  (together with special cases in `aur-build`) becomes redundant once #909 is implemented.