### PR TITLE
`build`, `chroot`: add `-I <pkg>`, and also `aur build --cargs` just in case

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -86,7 +86,7 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
           'margs:' 'buildscript:' 'null' 'dbext:' 'install:' 'cleanbuild'
-          'cargs:' 'makechrootpkg-args:')
+          'cargs:' 'makechrootpkg-args:' 'cargs-no-default' 'makechrootpkg-args-no-default')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -150,6 +150,8 @@ while true; do
 			shift; chroot_args+=(--install "$1") ;;
 		--cargs|--makechrootpkg-args)
 			shift; chroot_args+=(--makechrootpkg-args "$1") ;;
+		--cargs-no-default|makechrootpkg-args-no-default)
+			chroot_args+=(--makechrootpkg-args-no-default) ;;
         # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             chroot_build_args+=(--ignorearch)

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -79,13 +79,13 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 ## option parsing
-opt_short='a:d:D:U:AcCfnrsvzLNRST'
+opt_short='a:d:D:U:I:AcCfnrsvzLNRST'
 opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'verify' 'directory:' 'no-sync' 'pacman-conf:' 'remove' 'pkgver'
           'rmdeps' 'no-confirm' 'no-check' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
-          'margs:' 'buildscript:' 'null' 'dbext:' 'cleanbuild')
+          'margs:' 'buildscript:' 'null' 'dbext:' 'install:' 'cleanbuild')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -145,6 +145,8 @@ while true; do
             chroot_args+=(--checkpkg) ;;
         -T|--temp)
             chroot_args+=(--temp) ;;
+        -I|--install)
+			shift; chroot_args+=(--install "$1") ;;
         # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             chroot_build_args+=(--ignorearch)

--- a/lib/aur-build
+++ b/lib/aur-build
@@ -85,7 +85,8 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'rmdeps' 'no-confirm' 'no-check' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
-          'margs:' 'buildscript:' 'null' 'dbext:' 'install:' 'cleanbuild')
+          'margs:' 'buildscript:' 'null' 'dbext:' 'install:' 'cleanbuild'
+          'cargs:' 'makechrootpkg-args:')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -147,6 +148,8 @@ while true; do
             chroot_args+=(--temp) ;;
         -I|--install)
 			shift; chroot_args+=(--install "$1") ;;
+		--cargs|--makechrootpkg-args)
+			shift; chroot_args+=(--makechrootpkg-args "$1") ;;
         # makepkg options (common)
         -A|--ignorearch|--ignore-arch)
             chroot_build_args+=(--ignorearch)

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -54,11 +54,11 @@ usage() {
     exit 1
 }
 
-opt_short='C:D:M:x:ABNTU'
+opt_short='C:D:M:x:I:ABNTU'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
           'create' 'bind:' 'bind-rw:' 'user:' 'makepkg-args:'
           'ignorearch' 'namcap' 'checkpkg' 'temp' 'makechrootpkg-args:'
-          'margs:' 'cargs:' 'nocheck' 'suffix:')
+          'margs:' 'cargs:' 'nocheck' 'suffix:' 'install:')
 opt_hidden=('dump-options' 'status' 'path')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
@@ -110,6 +110,8 @@ while true; do
             makechrootpkg_args+=(-T) ;;
         --user)
             shift; makechrootpkg_args+=(-U "$1") ;;
+        -I|--install)
+			shift; makechrootpkg_args+=(-i "$1") ;;
         # XXX: cannot take arguments that contain commas (e.g. for file paths)
         --makechrootpkg-args|--cargs)
             shift; IFS=, read -a arg -r <<< "$1"

--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -9,7 +9,8 @@ machine=$(uname -m)
 
 # default arguments
 directory=/var/lib/aurbuild/$machine
-makechrootpkg_args=(-cu)  # XXX: allow unsetting these options?
+makechrootpkg_defaults=(-cu)
+makechrootpkg_args=()
 makechrootpkg_makepkg_args=()
 
 # default options
@@ -58,7 +59,8 @@ opt_short='C:D:M:x:I:ABNTU'
 opt_long=('directory:' 'pacman-conf:' 'makepkg-conf:' 'build' 'update'
           'create' 'bind:' 'bind-rw:' 'user:' 'makepkg-args:'
           'ignorearch' 'namcap' 'checkpkg' 'temp' 'makechrootpkg-args:'
-          'margs:' 'cargs:' 'nocheck' 'suffix:' 'install:')
+          'margs:' 'cargs:' 'nocheck' 'suffix:' 'install:'
+          'cargs-no-default' 'makechrootpkg-args-no-default')
 opt_hidden=('dump-options' 'status' 'path')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
@@ -116,6 +118,8 @@ while true; do
         --makechrootpkg-args|--cargs)
             shift; IFS=, read -a arg -r <<< "$1"
             makechrootpkg_args+=("${arg[@]}") ;;
+        --makechrootpkg-args-no-default|--cargs-no-default)
+            makechrootpkg_defaults=() ;;
         # other options
         --dump-options)
             printf -- '--%s\n' "${opt_long[@]}" ${AUR_DEBUG+"${opt_hidden[@]}"}
@@ -125,6 +129,8 @@ while true; do
     esac
     shift
 done
+
+makechrootpkg_args=( "${makechrootpkg_defaults[@]}" "${makechrootpkg_args[@]}" )
 
 # XXX: default paths can be set through the Makefile (`aur-chroot.in`)
 etcdir=/etc/aurutils shrdir=/usr/share/devtools

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -189,15 +189,18 @@ on the built package.
 .
 .TP
 .BR \-T ", " \-\-temp
-Build in a temporary container. (\fBmakechrootpkg \-T\fR) Temporary
-means that the user container has a random name and is removed on
-build completion.
+Build in a temporary container.
+.RB ( "makechrootpkg \-T" ) 
+.IP
+.B Note:
+This means that the user container has a random name and is removed on build completion.
 .
 .TP
 .BI \-\-user= USER
 Run the host
 .BR makepkg (8)
-instance as the specified user. (\fBmakechrootpkg \-U\fR)
+instance as the specified user.
+.RB ( "makechrootpkg \-U" ) 
 .
 .SH ENVIRONMENT
 .TP

--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -202,6 +202,13 @@ Run the host
 instance as the specified user.
 .RB ( "makechrootpkg \-U" ) 
 .
+.TP
+.BI \-I " PACKAGE" "\fR,\fP \-\-install=" PACKAGE
+Install
+.I PACKAGE
+into the container prior to building the package.
+.RB ( "makechrootpkg \-i" )
+.
 .SH ENVIRONMENT
 .TP
 .B AUR_PACMAN_AUTH


### PR DESCRIPTION
Add support for the `-I|--install <pkg>` flag to both `aur build` and `aur chroot` and pass this flag through to `makechrootpkg` (in makechrootpkg, it is a newly added flag `-i`).

Furthermore, add `aur build --cargs` (and pass this flag through to `aur chroot`) just in case there are future `makechrootpkg` flags we will not have exposed.

Depends on https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/214.

Fixes #1124.