### PR TITLE
`perl`: add `Depends.pm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
-AURUTILS_VERSION := 18.5
+AURUTILS_VERSION := 19
 endif
 AURUTILS_SHELLCHECK = $(wildcard lib/*)
 
@@ -25,7 +25,10 @@ completion:
 shellcheck: aur
 	@shellcheck -x -f gcc -e 1071 $(AURUTILS_SHELLCHECK)
 
-test: aur shellcheck
+prove:
+	@env -C perl prove
+
+test: aur shellcheck prove
 	@tests/parseopt-consistency
 
 install-aur: aur

--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -6,164 +6,9 @@ use v5.20;
 use List::Util qw(first);
 use AUR::Json qw(parse_json_aur write_json);
 use AUR::Query qw(query_multi);
+use AUR::Depends qw(depends graph prune);
 use AUR::Options qw(add_from_stdin);
 my $argv0 = 'depends';
-
-sub chain {
-    my ($targets, $types, $max_req) = @_;
-    my @depends = @{$targets};
-    my (%results, %reqby, %shlibs);
-
-    # Make every explicit target provide itself
-    for my $t (@{$targets}) {
-        $shlibs{$t} = [$t, 0];
-    }
-
-    for my $a (1..$max_req) {
-        say STDERR join(" ", "query: [$a]", @depends) if defined $ENV{'AUR_DEBUG'};
-
-        if ($a == $max_req) {
-            say STDERR "$argv0: total requests: $a (out of range)";
-            exit(34);
-        }
-        my @level = query_multi(terms => \@depends, type => 'info', callback => \&parse_json_aur);
-
-        if (not scalar(@level) and $a == 1) {
-            say STDERR "$argv0: no packages found";
-            exit(1);
-        }
-        @depends = ();
-
-        for my $node (@level) {
-            my $name = $node->{'Name'};
-            $results{$name} = $node;
-
-            # XXX: no check if provides has valid package version (vercmp)
-            for my $spec (@{$node->{'Provides'} // []}) {
-                my ($prov, $op, $ver) = split(/(<=|>=|<|=|>)/, $spec);
-
-                # XXX: only keeps the first provider
-                if (not defined $shlibs{$prov}) {
-                    # Use weights to make explicit provides take precedence
-                    $shlibs{$prov} = [$node->{'Name'}, $a];
-                }
-            }
-
-            # Filter out dependency types early (#882)
-            for my $deptype (@{$types}) {
-                next if not defined($node->{$deptype});  # no dependency of this type
-
-                for my $spec (@{$node->{$deptype}}) {
-                    # valid operators (important: <= before <)
-                    my ($dep, $op, $ver) = split(/(<=|>=|<|=|>)/, $spec);
-
-                    # populate reverse depends
-                    $reqby{$dep}{$node->{'Name'}} = $deptype;
-
-                    # avoid querying duplicate packages (#4)
-                    next if defined $results{$dep};
-                    push(@depends, $dep);
-
-                    # mark as incomplete (retrieved in next step or repo package)
-                    $results{$dep} = 'None';
-                }
-            }
-        }
-        last if not scalar(@depends);  # no further results
-    }
-    return \%results, \%reqby, \%shlibs;
-}
-
-sub chain_mod {
-    my ($results, $reqby, $shlibs, $provides, $showall) = @_;
-    %{$shlibs} = () if not $provides;
-
-    my %mod;
-    say STDERR "query: filtering results" if defined $ENV{'AUR_DEBUG'};
-
-    # Use generic variable $_ for iterating %results (pkgname, provides or both)
-    map {
-        # Take provides on the command-line into account (#837)
-        if (defined $shlibs->{$_} and $shlibs->{$_}->[1] == 1) {
-            my $name = $shlibs->{$_}->[0];
-
-            # Add data and reverse dependencies for AUR targets
-            $mod{$name} = $results->{$name};
-            $mod{$name}->{'RequiredBy'} = $reqby->{$_};
-
-            # Include `Self` dependency for every target (aur-sync, #1065)
-            $mod{$name}->{'RequiredBy'}->{$name} = 'Self';
-        }
-        # Avoid overriding provides with later target (random ordering of hash!)
-        elsif (not defined $mod{$_}) {
-            $mod{$_} = $results->{$_};
-            $mod{$_}->{'RequiredBy'} = $reqby->{$_};
-
-            # Include `Self` dependency for every target (aur-sync, #1065)
-            $mod{$_}->{'RequiredBy'}->{$_} = 'Self';
-        }
-    } grep {
-        $results->{$_} ne 'None'
-    } keys %{$results};
-
-    # Merge reverse dependencies for purely virtual targets, with corresponding
-    # packages specified on the command-line
-    map {
-        my $name = $shlibs->{$_}[0];
-
-        for my $dep (keys %{$reqby->{$_}}) {
-            $mod{$name}->{'RequiredBy'}{$dep} = $reqby->{$_}{$dep};
-        }
-    } grep {
-        $results->{$_} eq 'None' and defined $shlibs->{$_} and $shlibs->{$_}[1] > 0
-    } keys %{$results};
-
-    # Add reverse dependencies for non-AUR targets (--show-all)
-    if ($showall) {
-        map {
-            $mod{$_}->{'Name'} = $_;
-            $mod{$_}->{'RequiredBy'} = $reqby->{$_};
-        } grep {
-            $results->{$_} eq 'None'
-        } keys %{$results};
-    }
-
-    return \%mod, $reqby, $shlibs;
-}
-
-# Recursively remove nodes from dependency graph (#592)
-# Operates on modified graph: provides are solved first
-sub prune {
-    my ($mod, $installed) = @_;
-
-    for my $name (keys %{$mod}) {  # list returned by `keys` is a copy
-        # Remove installed targets from reverse dependencies
-        my $mod_reqby = $mod->{$name}->{'RequiredBy'};
-
-        for my $dep (keys %{$mod_reqby}) {
-            # Every reverse dependency needs to be checked against every pkgname
-            # assumed to be installed (quadratic complexity)
-            my $found = first { $dep eq $_ } @{$installed};
-
-            if (defined $found) {
-                delete $mod_reqby->{$found};
-            }
-        }
-    }
-
-    for my $name (keys %{$mod}) {
-        my $mod_reqby = $mod->{$name}->{'RequiredBy'};
-        if (not scalar keys %{$mod_reqby}) {
-            delete $mod->{$name};  # remove targets that are no longer required
-        }
-
-        my $found = first { $name eq $_ } @{$installed};
-        if (defined $found) {
-            delete $mod->{$name};  # remove targets that are installed
-        }
-    }
-    return $mod;
-}
 
 # tsv output for usage with aur-sync (aurutils <=10)
 sub table_v10_compat {
@@ -223,6 +68,7 @@ sub pairs {
 }
 
 unless(caller) {
+    # Command-line arguments
     use Getopt::Long;
     my $opt_depends      = 1;
     my $opt_makedepends  = 1;
@@ -233,6 +79,7 @@ unless(caller) {
     my $opt_show_all     = 0;  # implies $opt_pkgname = 1
     my $opt_reverse      = 0;
     my $opt_provides     = 1;
+    my $opt_verify       = 1;
     my $opt_installed    = [];
 
     GetOptions(
@@ -242,6 +89,7 @@ unless(caller) {
         'no-checkdepends'    => sub { $opt_checkdepends = 0 },
         'optdepends'         => \$opt_optdepends,
         'no-provides'        => sub { $opt_provides = 0 },
+        'no-verify'          => sub { $opt_verify = 0 },
         'n|pkgname'          => \$opt_pkgname,
         'b|pkgbase'          => sub { $opt_pkgname = 0 },
         'G|graph'            => sub { },  # noop
@@ -249,7 +97,7 @@ unless(caller) {
         'J|json'             => sub { $opt_mode = "json" },
         'jsonl'              => sub { $opt_mode = "jsonl" },
         'r|reverse'          => \$opt_reverse,
-        'a|all|show-all'     => \$opt_show_all
+        'a|all|show-all'     => \$opt_show_all        
         ) or exit(1);
 
     if (not scalar(@ARGV)) {
@@ -272,26 +120,48 @@ unless(caller) {
 
     # Array notation for `--assume-installed`
     @{$opt_installed} = map { split(',', $_) } @{$opt_installed};
-
-    # Resolve dependency tree
-    my ($results, $reqby, $shlibs) = chain_mod(chain(\@ARGV, \@types, 30), $opt_provides, $opt_show_all);
-
-    # Remove virtual dependencies with `--show-all` (#1063)
-    if ($opt_show_all and $opt_provides) {
-        # XXX: also include `None` dependencies with `Self` RequiredBy
-        my @virtual = grep {
-            $_ ne $shlibs->{$_}->[0] and $shlibs->{$_}->[1] > 0
-        } keys %{$shlibs};
-
-        $results = prune($results, \@virtual);
+    
+    # Dependency handling
+    sub callback_query {
+        query_multi(terms => @_, type => 'info', callback => \&parse_json_aur)
     }
 
+    # Retrieve AUR results (JSON -> dict -> extract depends -> repeat until none)
+    my ($results, $pkgdeps, $pkgmap) = depends(\@ARGV, \@types, \&callback_query, 30);
+
+    # Verify dependency requirements
+    my ($dag, $dag_foreign) = graph($results, $pkgdeps, $pkgmap, $opt_verify, $opt_provides);
+
+    my $removals = [];
+
+    # Remove virtual dependencies from dependency graph (#1063)
+    if ($opt_provides) {
+        my @virtual = keys %{$pkgmap};
+        # XXX: assumes <pkgmap> only contains keys with provides != pkgname
+        $removals = prune($dag, \@virtual);
+    }
     # Remove transitive dependencies for installed targets (#592)
     if (scalar @{$opt_installed}) {
-        $results = prune($results, $opt_installed);
+        $removals = prune($dag, $opt_installed);
+    }
+    # Remove packages no longer in graph from results
+    if (scalar @{$removals}) {
+        map { delete $results->{$_} } @{$removals};
     }
 
-    # Main operations
+    # Add `RequiredBy` to results
+    for my $name (keys %{$dag}) {
+        $results->{$name}->{'RequiredBy'} = $dag->{$name};
+    }
+    # Add foreign (non-AUR) packages to results
+    if ($opt_show_all) {
+        for my $name (keys %{$dag_foreign}) {
+            $results->{$name}->{'Name'} = $name;
+            $results->{$name}->{'RequiredBy'} = $dag_foreign->{$name};
+        }
+    }
+
+    # Format results
     if ($opt_mode eq 'pairs') {
         pairs($results, ($opt_pkgname or $opt_show_all) ? 'Name' : 'PackageBase', $opt_reverse);
     }

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -347,7 +347,10 @@ fi
 if [[ -s $tmp/argv ]]; then
     # shellcheck disable=SC2094
     # depends: $1 pkgname $2 required_by $3 pkgbase $4 pkgver $5 depends_type
-    aur depends --table --reverse "${depends_args[@]}" - <"$tmp"/argv >"$tmp"/depends
+    # XXX: dependency requirements are already computed by `aur-graph` below
+    # (possibly after local changes). Use `depends --no-verify` accordingly.
+    aur depends --table --reverse --no-verify \
+        "${depends_args[@]}" - <"$tmp"/argv >"$tmp"/depends
 else
     printf >&2 '%s: there is nothing to do\n' "$argv0"
     exit

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,18 @@
+## 19
+
+* `aur-build`
+  + early check for buildscript
+
+* `aur-depends`
+  + verify dependency version requirements by default
+  + add `--no-verify`
+
+* `aur-repo`
+  + fix invalid output with `--json --search` (#1126)
+
+* `perl`
+  + add `Depends.pm`
+
 ## 18.5
 
 * `aur-repo`

--- a/man1/aur-depends.1
+++ b/man1/aur-depends.1
@@ -116,6 +116,13 @@ Dependencies can be removed selectively with the
 option. Multiple packages can be specified by separating them with a
 comma.
 .
+.PP
+By default, dependency requirements are checked with
+.BR vercmp (8).
+This can be disabled with the
+.B \-\-no\-verify
+option.
+.
 .SH NOTES
 While versioned dependencies are listed, they are ignored when
 resolving the dependency graph. This is because versioned queries are

--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -5,7 +5,8 @@ use v5.20;
 
 use List::Util qw(first);
 use Carp;
-use Exporter qw(import); our @EXPORT = qw(vercmp extract depends prune graph);
+use Exporter qw(import);
+our @EXPORT_OK = qw(vercmp extract depends prune graph);
 our $VERSION = 'unstable';
 
 =head1 NAME

--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -1,0 +1,311 @@
+package AUR::Depends;
+use strict;
+use warnings;
+use v5.20;
+
+use List::Util qw(first);
+use Carp;
+use Exporter qw(import); our @EXPORT = qw(vercmp extract depends prune graph);
+our $VERSION = 'unstable';
+
+=head1 NAME
+
+AUR::Depends - Resolve dependencies from AUR package information
+
+=head1 SYNOPSIS
+
+  use AUR::Depends qw(vercmp extract depends prune graph);
+
+=head1 DESCRIPTION
+
+=head1 AUTHORS
+
+Alad Wenter <https://github.com/AladW/aurutils>
+
+=cut
+
+sub vercmp_run {
+    say STDERR __PACKAGE__ . ': vercmp ' . join(" ", @_)
+	if defined $ENV{'AUR_DEBUG'};
+
+    my @command = ('vercmp', @_);
+    my $child_pid = open(my $fh, "-|", @command) or die $!;
+    my $num;
+
+    if ($child_pid) {
+        $num = <$fh>;
+        waitpid($child_pid, 0);
+    }
+    die __PACKAGE__ . ": vercmp failure" if $?;
+    return $num;
+}
+
+sub vercmp_ops {
+    my %ops = (
+        '<'  => sub { $_[0] <  $_[1] },
+        '>'  => sub { $_[0] >  $_[1] },
+        '<=' => sub { $_[0] <= $_[1] },
+        '>=' => sub { $_[0] >= $_[1] },
+        );
+    return %ops;
+}
+
+=item vercmp
+
+This function provides a simple way to call C<vercmp(8)> from perl code.
+Instead of ordering versions on the command-line, this function takes
+an explicit comparison operator (<, >, =, <= or >=) as argument.
+
+Under the hood, this function calls the C<vercmp> binary explicitly.
+This avoids any rebuilds for C<libalpm.so> soname bumps. To keep the approach
+performant, C<vercmp> is only called when input versions differ.
+
+=cut
+
+sub vercmp {
+    my ($ver1, $ver2, $op) = @_;
+    my %cmp = vercmp_ops();
+
+    if (not defined $ver2 or not defined $op) {
+        return "true";  # unversioned dependency
+    }
+    elsif ($op eq '=') {
+        return $ver1 eq $ver2;
+    }
+    elsif (defined $cmp{$op}) {
+        # check if cmp(ver1, ver2) holds        
+        return $cmp{$op}->(vercmp_run($ver1, $ver2), 0);
+    }
+    else {
+        croak __PACKAGE__ . "invalid vercmp operation";
+    }
+}
+
+=item extract()
+
+Extracts dependency (C<$pkgdeps>) and provider (C<$pkgmap>)
+information from an array of package information hashes, such as
+those from C<Srcinfo.pm> or C<Query.pm>.
+
+Any I<new> dependencies are added to the returned array value. A
+dependency is considered I<new> if it has no existing entry in the
+C<$results> hash ref. This makes it efficient to use this function
+iteratively for retrieving the dependency graph of a set of targets.
+
+Verifying if any versioned dependencies can be fulfilled can be done
+subsequently with the C<graph> function.
+
+=cut
+
+sub extract {
+    # hash refs modified in place
+    my ($results, $pkgdeps, $pkgmap, $types, @level) = @_;
+    my @depends = ();
+
+    for my $node (@level) {
+        my $name    = $node->{'Name'};
+        my $version = $node->{'Version'};
+        $results->{$name} = $node;
+
+        # Iterate over explicit provides
+        for my $spec (@{$node->{'Provides'} // []}) {
+            my ($prov, $prov_version) = split(/=/, $spec);
+            
+            # XXX: the first provider takes precedence
+            #      keep multiple providers and warn on ambiguity instead
+            if (not defined $pkgmap->{$prov} and $prov ne $name) {
+                $pkgmap->{$prov} = [$name, $prov_version];
+            }
+        }
+        # Filter out dependency types early (#882)
+        for my $deptype (@{$types}) {
+            next if (not defined($node->{$deptype}));  # no dependency of this type
+
+            for my $spec (@{$node->{$deptype}}) {
+                # Push versioned dependency to global depends
+                push(@{$pkgdeps->{$name}}, [$spec, $deptype]);
+
+                # Valid operators (important: <= before <)
+                my ($dep, $op, $ver) = split(/(<=|>=|<|=|>)/, $spec);
+
+                # Avoid querying duplicate packages (#4)
+                next if defined $results->{$dep};
+                push(@depends, $dep);
+
+                # Mark as incomplete (retrieved in next step or repo package)
+                # XXX: do not write directly into <results>, but some other
+                # dict shared between <extract> calls
+                $results->{$dep} = 'None';
+            }
+        }
+    }
+    return @depends;
+}
+
+=item depends()
+
+Iteratively call C<extract()> with a callback function. The
+number of times the callback function may be called is specified as a
+separate parameter.
+
+=cut
+
+sub depends {
+    my ($targets, $types, $callback, $callback_max_a) = @_;
+    my @depends = @{$targets};
+
+    my (%results, %pkgdeps, %pkgmap);
+
+    # XXX: return $a for testing number of requests, e.g. 7 for ros-noetic-desktop
+    for my $a (1..$callback_max_a) {
+        say STDERR join(" ", "callback: [$a]", @depends) if defined $ENV{'AUR_DEBUG'};
+
+        # Check if request limits have been exceeded
+        if ($a == $callback_max_a) {
+            say STDERR __PACKAGE__ . ": total requests: $a (out of range)";
+            exit(34);
+        }
+
+        # Use callback to retrieve new hash of results
+        my @level = $callback->(\@depends);
+
+        if (not scalar(@level) and $a == 1) {
+            say STDERR __PACKAGE__ . ": no packages found";
+            exit(1);
+        }
+
+        # Retrieve next level of dependencies from results
+        @depends = extract(\%results, \%pkgdeps, \%pkgmap, $types, @level);
+
+        if (not scalar(@depends)) {
+            last;  # no further results
+        }
+    }
+    # XXX: workaround for extract() tallying packages in <results> dict
+    for my $pkg (keys %results) {
+        delete $results{$pkg} if $results{$pkg} eq 'None';
+    }
+    return \%results, \%pkgdeps, \%pkgmap;
+}
+
+=item graph()
+
+For a set of package-dependency relations (C<$pkgdeps>) and providers
+(C<$pkgmap>), verify if all dependencies and their versions can be
+fulfilled by the available set of packages. Version relations are
+checked with C<vercmp>.
+
+Two hashes are kept: one for packages in the set (C<$dag>), and
+another for packages outside it (C<$dag_foreign>). Only relations in
+the former are checked.
+
+=cut
+
+# XXX: <results> only used for versions and checking if AUR target
+sub graph {
+    my ($results, $pkgdeps, $pkgmap, $verify, $provides) = @_;
+    my (%dag, %dag_foreign);
+
+    my $dag_valid = 1;
+    $verify //= 1;  # run vercmp by default
+
+    # Iterate over packages
+    for my $name (keys %{$pkgdeps}) {
+        # Add a loop to isolated nodes (#402, #1065)
+        # XXX: distinguish between explicit (command-line) and
+        # implicit (dependencies) targets
+        $dag{$name}{$name} = 'Self';
+
+        # Iterate over dependencies
+        for my $dep (@{$pkgdeps->{$name}}) {
+            my ($dep_spec, $dep_type) = @{$dep};  # ['foo>=1.0', 'Depends']
+
+            # Retrieve dependency requirements
+            my ($dep_name, $dep_op, $dep_req) = split(/(<=|>=|<|=|>)/, $dep_spec);
+
+            if (defined $results->{$dep_name}) {
+                my $dep_ver = $results->{$dep_name}->{'Version'};
+
+                # Provides take precedence over regular packages,
+                # unless $provides is false.
+                my  ($prov_name, $prov_ver) = ($dep_name, $dep_ver);
+
+                if ($provides and defined $pkgmap->{$dep_name}) {
+                    ($prov_name, $prov_ver) = @{$pkgmap->{$dep_name}};
+                }
+
+                # Run vercmp with provider and versioned dependency
+                # XXX: a dependency can be both fulfilled by a package
+                # and a different package (provides). In this case an
+                # error should only be returned if neither fulfill the
+                # version requirement.
+                if (not $verify or vercmp($prov_ver, $dep_req, $dep_op)) {
+                    $dag{$prov_name}{$name} = $dep_type;
+                }
+                else {
+                    say STDERR "invalid node: $prov_name=$prov_ver (required: $dep_op$dep_req by: $name)";
+                    $dag_valid = 0;
+                }
+            }
+            # Dependency is foreign
+            else {
+                $dag_foreign{$dep_name}{$name} = $dep_type;
+            }
+        }
+    }
+    if (not $dag_valid) {
+        exit(1);
+    }
+    return \%dag, \%dag_foreign;
+}
+
+=item prune()
+
+Remove specified nodes from a dependency graph. Every dependency is
+checked against every pkgname provided (quadratic complexity).
+
+The keys of removed nodes are returned in an array.
+
+=cut
+
+# XXX: return complement dict instead of array
+sub prune {
+    my ($dag, $installed) = @_;
+    my @removals;
+
+    # Remove reverse dependencies for installed targets
+    for my $dep (keys %{$dag}) {  # list returned by `keys` is a copy
+        for my $name (keys %{$dag->{$dep}}) {
+            my $found = first { $name eq $_ } @{$installed};
+
+            if (defined $found) {
+                delete $dag->{$dep}->{$found};
+            }
+        }
+    }
+
+    for my $dep (keys %{$dag}) {
+        if (not scalar keys %{$dag->{$dep}}) {
+            delete $dag->{$dep};  # remove targets that are no longer required
+            push(@removals, $dep);
+        }
+        my $found = first { $dep eq $_ } @{$installed};
+
+        if (defined $found) {
+            delete $dag->{$dep};  # remove targets that are installed
+            push(@removals, $dep);
+        }
+    }
+    return \@removals;
+}
+
+=item levels()
+
+=cut
+
+# TODO: compute dependency levels (bfs)
+# sub levels {
+
+# }
+
+# vim: set et sw=4 sts=4 ft=perl:

--- a/perl/AUR/Json.pm
+++ b/perl/AUR/Json.pm
@@ -4,7 +4,7 @@ use warnings;
 use v5.20;
 
 use Exporter qw(import);
-our @EXPORT = qw(parse_json parse_json_aur write_json);
+our @EXPORT_OK = qw(parse_json parse_json_aur write_json);
 our $VERSION = 'unstable';
 
 =head1 NAME

--- a/perl/AUR/Json.pm
+++ b/perl/AUR/Json.pm
@@ -51,6 +51,10 @@ else {
     $aur_json = JSON::PP->new;
 }
 
+=item parse_json()
+
+=cut
+
 sub parse_json {
     my $str = shift;
     my $obj = $aur_json->incr_parse($str)
@@ -59,6 +63,10 @@ sub parse_json {
 
     return $obj;
 }
+
+=item parse_json_aur()
+
+=cut
 
 sub parse_json_aur {
     my $str = shift;
@@ -88,6 +96,10 @@ sub parse_json_aur {
         exit(4);
     }
 }
+
+=item write_json()
+
+=cut
 
 sub write_json {
     my $obj = shift;

--- a/perl/AUR/Options.pm
+++ b/perl/AUR/Options.pm
@@ -5,7 +5,7 @@ use v5.20;
 use Carp;
 
 use Exporter qw(import);
-our @EXPORT = qw(add_from_stdin);
+our @EXPORT_OK = qw(add_from_stdin);
 our $VERSION = 'unstable';
 
 =head1 NAME

--- a/perl/AUR/Options.pm
+++ b/perl/AUR/Options.pm
@@ -37,6 +37,10 @@ sub delete_elements {
     }
 }
 
+=item add_from_stdin()
+
+=cut
+
 sub add_from_stdin {
     my ($array_ref, $tokens) = @_;
     my @indices;

--- a/perl/AUR/Query.pm
+++ b/perl/AUR/Query.pm
@@ -5,7 +5,7 @@ use v5.20;
 use Carp;
 
 use Exporter qw(import);
-our @EXPORT = qw(urlencode query query_multi);
+our @EXPORT_OK = qw(urlencode query query_multi);
 our $VERSION = 'unstable';
 
 =head1 NAME

--- a/perl/AUR/Query.pm
+++ b/perl/AUR/Query.pm
@@ -39,6 +39,10 @@ our $aur_rpc      = $ENV{AUR_QUERY_RPC} // $aur_location . "/rpc";
 our $aur_rpc_ver  = $ENV{AUR_QUERY_RPC_VERSION} // 5;
 our $aur_splitno  = $ENV{AUR_QUERY_RPC_SPLITNO} // 5000;
 
+=item urlencode()
+
+=cut
+
 # https://code.activestate.com/recipes/577450-perl-url-encode-and-decode/#c6
 sub urlencode {
     my $s = shift;
@@ -68,6 +72,10 @@ sub query_curl {
     return $str;
 }
 
+=item query()
+
+=cut
+
 # XXX: accept arbitrary suffix/parameter instead of $by
 sub query {
     my %args = (type => undef, term => undef, by => undef, callback => undef, @_);
@@ -85,6 +93,10 @@ sub query {
     defined $args{callback} ? return $args{callback}->($response)
                             : return $response;
 }
+
+=item query_multi()
+
+=cut
 
 # XXX: this can also be used to split GET requests
 sub query_multi {

--- a/perl/t/depends.t
+++ b/perl/t/depends.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use v5.20;
+use Test::More;
+
+# Check if module can be imported
+require_ok "AUR::Depends";
+
+use AUR::Depends qw(vercmp extract depends prune graph);
+
+ok(vercmp("1.0", "1.0", '='));
+ok(vercmp("1.0a", "1.0b", '<'));
+ok(vercmp("1", "1.0", '<='));
+ok(vercmp("1:1", "1", '>'));
+ok(vercmp("2.0", "1.0", '>='));
+ok(vercmp("abc", undef, '<'));
+
+done_testing();

--- a/tests/package
+++ b/tests/package
@@ -27,10 +27,7 @@ jellyfin
 openrct2-git
 
 # cyclic dependencies - required removal of makedeps
-mingw-w64-gcc-base
-
-# 100+ depends
-plasma-git-meta
+#mingw-w64-gcc-base
 
 # 200+ depends 
 ros-noetic-desktop


### PR DESCRIPTION
This will allow to have a common interface between `aur-graph` and `aur-depends`, such that local .SRCINFO files can be handled similar to packages available on the AUR.

It also adds checking version requirements with `aur-depends`, which was previously only available in `aur-graph`.

The tests are severely lacking at this point, although all the cases in `test/package` pass. 