### PR TITLE
Fix formating of aur-view(1) manual

### DIFF
--- a/man1/aur-view.1
+++ b/man1/aur-view.1
@@ -45,7 +45,8 @@ environment variable, if set. These revisions are then used to
 generate diffs with
 .BR git\-diff (1)
 or
-.BR git\-log (1). Any changes to
+.BR git\-log (1).
+Any changes to
 .B .SRCINFO
 and
 .B .gitignore


### PR DESCRIPTION
The `.BR` macro seems to eliminate all spaces between words.