### PR TITLE
`sync`: make `--clean` optional

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -85,7 +85,7 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'rmdeps' 'no-confirm' 'no-check' 'ignore-arch' 'log' 'new'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
-          'margs:' 'buildscript:' 'null' 'dbext:')
+          'margs:' 'buildscript:' 'null' 'dbext:' 'cleanbuild')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -158,6 +158,8 @@ while true; do
         # makepkg options (build)
         -C|--clean)
             makepkg_args+=(--clean) ;;
+        --cleanbuild)
+            makepkg_args+=(--cleanbuild) ;;
         -L|--log)
             makepkg_args+=(--log) ;;
         --nocheck|--no-check)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -14,7 +14,7 @@ PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 unset -v CDPATH
 
 # default arguments
-build_args=(--clean --syncdeps) build_repo_args=()
+build_args=(--syncdeps) build_repo_args=()
 depends_args=() view_args=() filter_args=() fetch_args=() graph_args=()
 
 # default options
@@ -109,15 +109,15 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 # option parsing
-opt_short='d:D:k:U:AcfLnorRSTuv'
+opt_short='d:D:k:U:ACcfLnorRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
-          'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force'
-          'ignore-arch' 'log' 'no-confirm' 'no-ver' 'no-graph' 'no-sync' 'no-ver-argv'
-          'no-view' 'no-provides' 'no-build' 'rmdeps' 'sign' 'temp' 'upgrades'
-          'pkgver' 'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:'
-          'remove' 'provides-from:' 'new' 'prevent-downgrade' 'verify'
-          'makepkg-args:' 'format:' 'no-check' 'keep-going:' 'user:'
-          'rebase' 'reset' 'ff' 'exclude:' 'columns' 'prefix' 'save:')
+          'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force' 'ignore-arch'
+          'log' 'no-confirm' 'no-ver' 'no-graph' 'no-sync' 'no-ver-argv' 'no-view'
+          'no-provides' 'no-build' 'rmdeps' 'sign' 'temp' 'upgrades' 'pkgver'
+          'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:' 'remove'
+          'provides-from:' 'new' 'prevent-downgrade' 'verify' 'makepkg-args:'
+          'format:' 'no-check' 'keep-going:' 'user:' 'rebase' 'reset' 'ff' 'exclude:'
+          'columns' 'prefix' 'save:' 'clean' 'cleanbuild')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nosync' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
@@ -207,6 +207,10 @@ while true; do
             build_args+=(--chroot) ;;
         -f|--force)
             build_args+=(--force) ;;
+        -C|--clean)
+            build_args+=(--clean) ;;
+        --cleanbuild)
+            build_args+=(--cleanbuild) ;;
         --makepkg-args|--margs)
             shift; build_args+=(--margs "$1") ;;
         --makepkg-conf)

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -17,6 +17,8 @@
 * `aur-sync`
   + document `aur-view` options
   + detect local repositories with `--chroot` configuration (#1135)
+  + add `--clean` / `-C`, `--cleanbuild`
+    - default build command changed to `aur build --syncdeps`
 
 * `perl`
   + add `Depends.pm`

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -2,6 +2,7 @@
 
 * `aur-build`
   + early check for buildscript
+  + add `--cleanbuild`
 
 * `aur-depends`
   + verify dependency version requirements by default

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -242,6 +242,11 @@ Clean up leftover work files and directories after a successful build.
 .RB ( makepkg " " \-\-clean )
 .
 .TP
+.BR \-\-cleanbuild
+Remove the source directory before building the package.
+.RB ( "makepkg \-\-cleanbuild" )
+.
+.TP
 .BI \-\-buildscript= NAME
 Read the package script
 .I NAME

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -223,7 +223,7 @@ for all repositories.
 .
 .SS Build options
 The default build command is
-.BR "aur-build \-\-clean \-\-syncdeps" .
+.BR "aur-build \-\-syncdeps" .
 Specifying
 .BR aur\-build (1)
 options such as
@@ -255,6 +255,16 @@ Do not wait for user input when installing or removing build dependencies.
 .TP
 .BR \-o ", " \-\-nobuild ", " \-\-no\-build
 Print target packages and their paths instead of building them.
+.
+.TP
+.BR \-C ", " \-\-clean
+Clean up leftover work files and directoreis after a successful build.
+.RB ( "aur build \-C" )
+.
+.TP
+.BR \-\-cleanbuild
+Remove the source directory before building the package.
+.RB ( "aur build \-\-cleanbuild" )
 .
 .TP
 .BR \-\-pkgver

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -389,7 +389,7 @@ in $PATH, for example
     AURDEST=${AURDEST:\-$XDG_CACHE_HOME/aurutils/sync}
 
     # Assumes build files were retrieved through git(1)
-    find "$AURDEST" \-name .git \-execdir git clean \-xf \e;
+    find "$AURDEST" \-name .git \-execdir git clean \-xdf \e;
 
     # Print directories which do not contain a PKGBUILD file
     for d in "$AURDEST"/*; do


### PR DESCRIPTION
This makes `--clean` optional and exposes `--cleanbuild` directly without needing to resort to `--margs`. To compensate for the additional storage, add `-d` to `git clean` in the `aur-gc` example.