### PR TITLE
repo: remove explicit file/directory checks

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -193,18 +193,10 @@ case $db_query in
         ;;
 esac
 
-# check file attributes
-if [[ ! -d $db_root ]]; then
-    printf >&2 '%s: %q: no such directory\n' "$argv0" "$db_root"
-    exit 2
-elif [[ ! -f $db_path ]]; then
-    printf >&2 '%s: %q: no such file\n' "$argv0" "$db_path"
-    exit 2
-fi
-
 # resolve repo-add symlink
-db_path=$(realpath -- "$db_path")
-db_root=$(realpath -- "$db_root")
+# path is not required to exist for printf modes (# )
+db_path=$(realpath --canonicalize-missing -- "$db_path")
+db_root=$(realpath --canonicalize-missing -- "$db_root")
 
 # database operations
 case $mode in
@@ -215,7 +207,7 @@ case $mode in
         aur repo-parse "${parse_args[@]}" -p "$db_path" --jsonl | aur format "${format_args[@]}" -f "$format"
         ;;
     upgrades)
-        aur repo-parse "${parse_args[@]}" -p "$db_path" --list | aur vercmp "${vercmp_args[@]}"
+        aur repo-parse "${parse_args[@]}" -p "$db_path" --list  | aur vercmp "${vercmp_args[@]}"
         ;;
     attr)
         aur repo-parse "${parse_args[@]}" -p "$db_path" --attr "$attr"

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -6,6 +6,7 @@
 
 * `aur-depends`
   + verify dependency version requirements by default
+  + only include `Self` targets for command-line arguments (`--table`, #1136)
   + add `--no-verify`
 
 * `aur-graph`
@@ -13,12 +14,16 @@
 
 * `aur-repo`
   + fix invalid output with `--json --search` (#1126)
+  + paths are not required to exist with `--path` or `--status`
 
 * `aur-sync`
   + document `aur-view` options
   + detect local repositories with `--chroot` configuration (#1135)
   + add `--clean` / `-C`, `--cleanbuild`
     - default build command changed to `aur build --syncdeps`
+
+* `aur(1)`
+  + use `git-clean -ixd` to clean directories with `aur-gc`
 
 * `perl`
   + add `Depends.pm`, `Repo.pm`


### PR DESCRIPTION
Consider a script `aur-repo-init`, which aims to create a local repository by the file paths defined in pacman.conf. With a file/directory check in place, `aur-repo` would fail to print the necessary paths, even though the repository is not directly accessed.

Remove the checks to address this use case. Necessary file checks are still done by `aur-repo-parse`, when actually reading from the local repository. The same holds for `aur-build` for write access.

Reported-by: Ivan Shapovalov <intelfx@intelfx.name>