### PR TITLE
docs: ccache with aur-chroot needs --bind-rw

### DIFF
--- a/man1/aur-chroot.1
+++ b/man1/aur-chroot.1
@@ -328,7 +328,7 @@ Ensure write access to
 directories on the host:
 .EX
 
-  # aur chroot --build --bind /home/_ccache:/build/.ccache
+  # aur chroot --build --bind-rw /home/_ccache:/build/.ccache
 
 .EE
 Necessary


### PR DESCRIPTION
Otherwise you'd get 'read-only filesystem' errors when trying to build.
