### PR TITLE
`graph`: fix handling of `optdepends`

### DIFF
--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -47,12 +47,20 @@ function has_valid_arch(attr) {
     return !i || (substr(attr, i+1) in arch)
 }
 
+function print2(str1, str2) {
+    if (REVERSE)
+        printf("%s\t%s\n", str1, str2)
+    else
+        printf("%s\t%s\n", str2, str1)
+}
+
 BEGIN {
     DEPENDS = setopt(DEPENDS, 1)
     MAKEDEPENDS = setopt(MAKEDEPENDS, 1)
     CHECKDEPENDS = setopt(CHECKDEPENDS, 1)
     OPTDEPENDS = setopt(OPTDEPENDS, 0)
     PRINTALL = setopt(PRINTALL, 0)
+    REVERSE = setopt(REVERSE, 0)
 }
 
 $1 == "pkgbase" {
@@ -121,11 +129,11 @@ END {
 
     for (pkgbase in dep_counts) {
         # add a loop to isolated nodes (#402)
-        printf("%s\t%s\n", pkgbase, pkgbase)
+        print2(pkgbase, pkgbase)
 
         for (dep = 1; dep <= dep_counts[pkgbase]; dep++) {
             if (PRINTALL) {
-                printf("%s\t%s\n", pkgbase, pkg_deps[pkgbase, dep])
+                print2(pkgbase, pkg_deps[pkgbase, dep])
                 continue
             }
             dep_op = "-" # unversioned / no comparison
@@ -159,7 +167,7 @@ END {
 
             # run vercmp with provider and versioned dependency
             if (get_vercmp(ver_map[dep_pkgname], dep_pkgver, dep_op)) {
-                printf("%s\t%s\n", pkgbase, pkg_map[dep_pkgname])
+                print2(pkgbase, pkg_map[dep_pkgname])
             } else {
                 printf("invalid node: %s %s (required: %s%s)\n",
                        dep_pkgname, ver_map[dep_pkgname], dep_op, dep_pkgver) > "/dev/stderr"

--- a/lib/aur-graph
+++ b/lib/aur-graph
@@ -83,23 +83,28 @@ $1 == "arch" {
 }
 
 index($1, "depends") == 1 && !in_split_pkg {
-    if (DEPENDS && has_valid_arch($1))
+    if (DEPENDS && has_valid_arch($1)) {
         pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3
+    }
 }
 
 index($1, "makedepends") == 1 && !in_split_pkg {
-    if (MAKEDEPENDS && has_valid_arch($1))
+    if (MAKEDEPENDS && has_valid_arch($1)) {
         pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3
+    }
 }
 
 index($1, "checkdepends") == 1 && !in_split_pkg {
-    if (CHECKDEPENDS && has_valid_arch($1))
+    if (CHECKDEPENDS && has_valid_arch($1)) {
         pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3
+    }
 }
 
 index($1, "optdepends") == 1 && !in_split_pkg {
-    if (OPTDEPENDS && has_valid_arch($1))
-        pkg_deps[pkgbase, ++dep_counts[pkgbase]] = $3
+    if (OPTDEPENDS && has_valid_arch($1)) {
+        split($3, optname, ":")  # split optdepends name from description
+        pkg_deps[pkgbase, ++dep_counts[pkgbase]] = optname[1]
+    }
 }
 
 NF == 0 {

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -411,11 +411,11 @@ if (( graph )); then
     if ! { while read -r pkg; do
                [[ $pkg ]] && printf '%s\0' "$pkg/.SRCINFO"
            done
-         } | xargs -0 cat -- | aur graph "${graph_args[@]}"
+         } | xargs -0 cat -- | aur graph "${graph_args[@]}" REVERSE=1
     then
         printf >&2 '%s: failed to verify dependency graph\n' "$argv0"
         exit 1
-    fi <"$tmp"/queue | swap >"$tmp"/graph
+    fi <"$tmp"/queue >"$tmp"/graph
 
     # Recompute dependencies to include `provides` (#837)
     tsort < "$tmp"/graph >"$tmp"/queue || exit 22

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,17 @@
+## 19.6
+
+* `aur-graph`
+  + add `REVERSE`
+
+* `aur-sync`
+  + fix `--optdepends` dependency order (#1164)
+
+* `aur-view`
+  + diff from `/dev/null` on invalid revision (#1162)
+
+* `perl`
+  + `AUR::Depends`: warn about targets that are not found, refactor (#1165)
+
 ## 19.5
 
 * `aur-repo`


### PR DESCRIPTION
Optdepends have both a package name and a description, separated by a colon. Take this into account. Additionally, make aur-sync preserve the exit status from `aur-graph`.