### PR TITLE
Depends.pm: warn about targets that are not found

### DIFF
--- a/lib/aur-depends
+++ b/lib/aur-depends
@@ -128,7 +128,7 @@ unless(caller) {
 
     # Retrieve AUR results
     #    JSON -> hash -> extract depends[] -> repeat until none -> prune
-    my ($results, $dag, $dag_foreign) = get(\@ARGV, \@types, \&callback_query,
+    my ($results, $dag, $dag_foreign) = solve(\@ARGV, \@types, \&callback_query,
         $opt_verify, $opt_provides, $opt_installed);
 
     # Add `RequiredBy` to results

--- a/perl/AUR/Depends.pm
+++ b/perl/AUR/Depends.pm
@@ -128,8 +128,7 @@ sub recurse {
         my @level = $callback->(\@depends);
 
         if (not scalar(@level) and $a == 1) {
-            say STDERR __PACKAGE__ . ": no packages found";
-            exit(1);
+            last;  # no results
         }
         # Retrieve next level of dependencies from results
         @depends = ();
@@ -163,6 +162,17 @@ sub recurse {
         if (not scalar(@depends)) {
             last;  # no further results
         }
+    }
+    # Print which targets have not been found
+    for my $name (@{$targets}) {
+        if (not defined $results{$name}) {
+            say STDERR __PACKAGE__ . ": target not found: $name";
+        }
+    }
+    # Check if results are available
+    if (scalar keys %results == 0) {
+        say STDERR __PACKAGE__ . ": no packages found";
+        exit(1);
     }
     # Check if request limits have been exceeded
     if ($a == $aur_callback_max) {

--- a/perl/t/depends.t
+++ b/perl/t/depends.t
@@ -7,7 +7,7 @@ use Test::More;
 # Check if module can be imported
 require_ok "AUR::Depends";
 
-use AUR::Depends qw(vercmp extract prune graph get);
+use AUR::Depends qw(vercmp recurse prune graph solve);
 
 ok(vercmp("1.0", "1.0", '='));
 ok(vercmp("1.0a", "1.0b", '<'));


### PR DESCRIPTION
And some general refactoring. Maybe the high-level `get()` should be renamed to `solve()`, with `extract()` renamed to something else (`recurse()`?)