### PR TITLE
repo: warn when local repo is not configured

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -186,14 +186,16 @@ if [[ ! $db_name ]]; then
 
 # check $db_name is a configured pacman repository (local or remote, #1113)
 elif ! [[ ${conf_sync_serv[$db_name]} ]]; then
-    printf >&2 "%s: repository %q not configured\n" "$err_prefix" "$db_name"
-    exit 2
+    printf >&2 "warning: repository %s not configured\n" "$db_name"
 fi
 
 # basic file checks
 case $db_query in
     file)
-        if [[ $db_root == *://* ]]; then
+        if ! [[ $db_root ]]; then
+            printf >&2 '%s: database root not specified\n' "$argv0"
+            exit 2
+        elif [[ $db_root == *://* ]]; then
             printf >&2 '%s: %q: object is remote (use -S to query)\n' "$argv0" "$db_root"
             exit 66
         fi

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,13 @@
+## 19.9
+
+* `aur-repo`
+  + warn if a local repository is not configured in pacman.conf (instead of exiting)
+
+## 19.8
+
+* `aur-graph`
+  + fix for "add `-REVERSE`" in 19.6
+
 ## 19.7
 
 * `perl`


### PR DESCRIPTION
In #1110 a mandatory check was added for the local repository to be configured in pacman.conf. However, the bulk of the aur-repo functionality is available without configuration in pacman.conf, provided the repository root (`--root`) is specified by the user.

@BrainDamage