### PR TITLE
`repo`: add `--init`

### DIFF
--- a/lib/aur-repo
+++ b/lib/aur-repo
@@ -21,7 +21,7 @@ usage() {
 # option parsing
 opt_short='c:f:d:i:r:s:F:almqtuJS'
 opt_long=('config:' 'database:' 'root:' 'all' 'list' 'path' 'list-path' 'list-repo'
-          'search:' 'search-by:' 'list-attr' 'sync' 'upgrades' 'table' 'quiet' 
+          'search:' 'search-by:' 'list-attr' 'sync' 'upgrades' 'table' 'quiet' 'init'
           'attr:' 'json' 'jsonl' 'format:' 'delim:' 'dbext:' 'missing' 'ignore:' 'ignore-by:')
 opt_hidden=('dump-options' 'repo:' 'repo-list' 'path-list' 'attr-list' 'status' 'field:')
 
@@ -60,6 +60,8 @@ while true; do
             mode=upgrades; vercmp_args+=(-a) ;;
         -u|--upgrades)
             mode=upgrades ;;
+        --init)
+            mode=init ;;
         -q|--quiet)
             parse_args+=(-q); vercmp_args+=(-q) ;;
         -S|--sync)
@@ -136,7 +138,7 @@ else
 fi
 
 # existing path is optional for printf modes (#1142)
-if (( missing )); then
+if (( missing )) || [[ $mode == 'init' ]]; then
     realpath_args=(-m)
 else
     # require all path components to exist
@@ -225,6 +227,21 @@ case $mode in
     attr)
         aur repo-parse "${parse_args[@]}" -p "$db_path" --attr "$attr"
         ;;
+    init)
+        # repo-add does not create empty databases for pacman>=6.0, <7.0 (#1168)
+        filename=$db_root/$db_name.${db_ext:-db.tar.gz}
+        dblink=${filename%.tar*}
+
+        if [[ $filename == "$dblink" ]]; then
+            printf '%s: error: invalid database archive extension' "$argv0"
+            exit 1
+        fi
+        tar zcf "$filename" -T /dev/null --backup=simple --suffix='.old'
+
+        # repo-add symlinks >:(
+        if ! { ln -sf "$filename" "$dblink" || ln -f "$filename" "$dblink"; } 2>/dev/null; then
+            cp "$filename" "$dblink"
+        fi ;;
     path)
         printf '%s\n' "$db_path"
         ;;

--- a/man1/aur-repo.1
+++ b/man1/aur-repo.1
@@ -108,6 +108,14 @@ Unless
 is specified, all paths must exist.
 .
 .TP
+.BR \-\-init
+Create an empty database at 
+.IR <root>/<name>.db.tar.gz .
+.IP
+Equivalent to
+.IR "repo\-add <root>/<name>.db.tar.gz" .
+.
+.TP
 .BR \-\-path
 List the resolved path of the selected
 .BR pacman (8)

--- a/man1/aur.1
+++ b/man1/aur.1
@@ -167,6 +167,12 @@ Create the repository root and database:
 .PP
 .EX
     $ sudo install \-d /home/custompkgs \-o $USER
+    $ aur repo \-d custom \-\-init
+.EE
+.PP
+The last step is equivalent to:
+.PP
+.EX
     $ repo\-add /home/custompkgs/custom.db.tar.gz
 .EE
 .PP

--- a/tests/issue/0085
+++ b/tests/issue/0085
@@ -21,7 +21,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 # create temporary pacman database
 mkdir -p "$tmp"/pacman/{local,sync}

--- a/tests/issue/0216
+++ b/tests/issue/0216
@@ -20,7 +20,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 # issue 216: aur-sync with unset variables
 env -u AUR_REPO -u AUR_DBROOT -u AUR_DBEXT -u XDG_CACHE_HOME -u AURDEST -u AUR_SYNC_NINJA AUR_ENV=/dev/null \

--- a/tests/issue/0378
+++ b/tests/issue/0378
@@ -30,9 +30,9 @@ Server = file://$tmp3
 EOF
 
 # create local repository
-repo-add "$tmp1/$tmp1_uid".db.tar
-repo-add "$tmp2/$tmp2_uid".db.tar
-repo-add "$tmp3/$tmp3_uid".db.tar
+aur repo --root "$tmp1" --repo "$tmp1_uid" --init
+aur repo --root "$tmp2" --repo "$tmp2_uid" --init
+aur repo --root "$tmp3" --repo "$tmp3_uid" --init
 
 # issue 378: repository selection with AUR_REPO
 { IFS=: read -r _ repo

--- a/tests/issue/0513
+++ b/tests/issue/0513
@@ -31,7 +31,7 @@ package() {
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 # issue 513: PKGDEST (environment) should be ignored
 env -C "$tmp" -u AUR_REPO -u AUR_DBROOT -u AUR_DBEXT -u MAKEPKG AUR_ENV=/dev/null PKGDEST=/does/not/exist \

--- a/tests/issue/0714
+++ b/tests/issue/0714
@@ -33,7 +33,7 @@ package() {
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 # issue 714: select repository without -d or --root
 # TODO: use --dbpath to avoid privilege escalation

--- a/tests/issue/0741
+++ b/tests/issue/0741
@@ -20,7 +20,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 config=(--pacman-conf "$tmp"/pacman.conf)
 pkg=aurutils

--- a/tests/issue/0880
+++ b/tests/issue/0880
@@ -20,7 +20,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 pkg=weston-git
 pkg_ignored=wayland-git
 

--- a/tests/issue/0900
+++ b/tests/issue/0900
@@ -20,7 +20,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 pkg=weston-git
 pkg_ignored=wayland-git
 

--- a/tests/issue/0908
+++ b/tests/issue/0908
@@ -22,7 +22,7 @@ Server = file://$tmp
 EOF
 
 # create local repository
-repo-add "$tmp/$tmp_uid".db.tar
+aur repo --root "$tmp" --repo "$tmp_uid" --init
 
 env -u AUR_REPO -u AUR_DBROOT -u AUR_DBEXT AUR_ENV=/dev/null AUR_SYNC_USE_NINJA=0 AURDEST="$tmp" \
     aur sync --no-view --no-build --pacman-conf "$tmp"/pacman.conf "$cycles_target"

--- a/tests/issue/1148
+++ b/tests/issue/1148
@@ -1,6 +1,6 @@
 #!/bin/bash
 tmp=$(mktemp -d)
-repo-add "$tmp"/extra.db.tar.gz || exit
+aur repo --root "$tmp" --repo extra --init || exit
 
 aur repo -d extra
 (( $? == 66 )) || exit


### PR DESCRIPTION
Workaround for a regression in `pacman` where `repo-add` no longer creates empty databases.

Closes #1168