### PR TITLE
view: set orderFile on every call

### DIFF
--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -243,14 +243,6 @@ mkdir -pm 0700 -- "${TMPDIR:-/tmp}/aurutils-$UID"
 tmp=$(mktemp -d --tmpdir "aurutils-$UID/$argv0.XXXXXXXX")
 trap 'trap_exit' EXIT
 
-# Default to showing PKGBUILD first in patch. (#399)
-orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
-mkdir -p -- "${orderfile%/*}"
-
-if [[ ! -s $orderfile ]]; then
-    printf 'PKGBUILD\n' > "$orderfile"
-fi
-
 if (( rotate )); then
     if { hash caesar && target=$(aur pkglist | shuf -n 1); } 2>/dev/null; then
         exec bash -c "{ aur \"$argv0\" -c \"$target\" && repo-elephant | caesar 13; } 2>&1 | caesar 13"
@@ -389,19 +381,7 @@ fi
 
 if (( download )); then
     msg >&2 "Retrieving package files"
-    aur fetch -S "${fetch_args[@]}" --discard --results "$tmp"/fetch_results - < "$tmp"/queue >&2
-
-    # shellcheck disable=SC2034
-    while IFS=: read -r mode rev_old rev path; do
-        path=${path#file://} name=${path##*/}
-
-        case $mode in
-            clone)
-                git -C "$path" config diff.orderFile "$orderfile" ;;
-            fetch|merge|rebase|reset)
-                ;;
-        esac
-    done < "$tmp"/fetch_results
+    aur fetch -S "${fetch_args[@]}" --discard - < "$tmp"/queue >&2
 else
     xargs -a "$tmp"/queue stat >/dev/null || exit 2 # ensure all directories are available
 fi

--- a/lib/aur-view
+++ b/lib/aur-view
@@ -84,6 +84,14 @@ trap 'trap_exit' EXIT
 # Directory for git checksums (revisions viewed by the user, #379)
 mkdir -p -- "$AUR_VIEW_DB"
 
+# Default to showing PKGBUILD first in patch. (#399)
+orderfile=$XDG_CONFIG_HOME/aurutils/$argv0/orderfile
+mkdir -p -- "${orderfile%/*}"
+
+if [[ ! -s $orderfile ]]; then
+    printf 'PKGBUILD\n' > "$orderfile"
+fi
+
 # Take input from a file instead of redirecting stdin (#871)
 packages=()
 if [[ -v queue ]]; then
@@ -112,6 +120,9 @@ declare -A heads
 
 for pkg in "${packages[@]}"; do
     git() { command git -C "$pkg" "$@"; }
+
+    # Point git to current orderFile path (#1167)
+    git config diff.orderFile "$orderfile"
 
     # Ensure every directory is a git repository (--continue)
     if head=$(git rev-parse "${revision:-HEAD}"); then

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,8 @@
+## 19.10
+
+* `aur-sync`
+  + move git `orderFile` to `XDG_CONFIG_HOME/aurutils/view/orderfile` (#1167)
+
 ## 19.9
 
 * `aur-repo`


### PR DESCRIPTION
This moves the `git orderFile` logic from `aur-sync` to `aur-view`. Incidentally this was the only remaining `git` call in `aur-sync`.

Calling `git config diff.orderFile` on every `aur-view` call, instead of after a `git clone`, ensures `orderFile` always points to a valid path. For example, if `HOME=/temphome/user` aur sync ...` is run for a series of new(ly cloned) packages, subsequent calls `aur sync ...` using the default `HOME=/home/user` value would still rely on the orderFile in `/temphome/user`. This leads to errors if the path is deleted.

Closes #1167