### PR TITLE
chroot: make --status default if no modes are specified

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -186,7 +186,7 @@ fi
 
 # Print paths to container and used makepkg/pacman paths. This does
 # not require a priorly created container.
-if (( status )); then
+if (( status )) || ! (( update + build + create )); then
     printf 'chroot:%s\npacman:%s\nmakepkg:%s\n' "$directory" "$pacman_conf" "$makepkg_conf"
     exit 0
 fi
@@ -234,6 +234,9 @@ if (( create )); then
     if [[ ! -d $directory/root ]]; then
         # shellcheck disable=SC2086
         $AUR_PACMAN_AUTH mkarchroot -C "$pacman_conf" -M "$makepkg_conf" "$directory"/root "${base_packages[@]}"
+    else
+        printf '%s: --create: there is nothing to do\n' "$argv0"
+        create=0
     fi
 fi >&2
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,5 +1,8 @@
 ## 20
 
+* `aur-chroot`
+  + run `--status` if no modes are specified
+
 * `aur-sync`
   + move git `orderFile` to `XDG_CONFIG_HOME/aurutils/view/orderfile` (#1167)
 


### PR DESCRIPTION
This matches `aur-repo` behavior. In addition, if $directory/root is existing, print `there is nothing to do` with `--create`.