### PR TITLE
`sync`: automatic `gnupg` key retrieval

### DIFF
--- a/lib/aur-build
+++ b/lib/aur-build
@@ -86,7 +86,7 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
           'margs:' 'buildscript:' 'null' 'dbext:' 'cleanbuild' 'cargs:'
-          'makechrootpkg-args:')
+          'makechrootpkg-args:' 'makepkg-gnupghome:')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -119,6 +119,8 @@ while true; do
         --makepkg-conf)
             shift; makepkg_conf=$1
             chroot_args+=(--makepkg-conf "$1") ;;
+        --makepkg-gnupghome)
+            shift; AUR_MAKEPKG_GNUPGHOME="$1" ;;
         --pacman-conf)
             shift; pacman_conf=$1
             chroot_args+=(--pacman-conf "$1") ;;
@@ -202,6 +204,12 @@ done
 
 # Assign environment variables
 db_ext=${db_ext:-$AUR_DBEXT} db_name=${db_name:-$AUR_REPO} db_root=${db_root:-$AUR_DBROOT}
+
+# Set GNUPGHOME for makepkg if AUR_MAKEPKG_GNUPGHOME is set (#1129)
+makepkg_env=()
+if [[ -v AUR_MAKEPKG_GNUPGHOME ]]; then
+    makepkg_env+=("GNUPGHOME=$AUR_MAKEPKG_GNUPGHOME")
+fi
 
 # shellcheck disable=SC2174
 mkdir -pm 0700 -- "${TMPDIR:-/tmp}/aurutils-$UID"
@@ -388,10 +396,11 @@ while IFS= read "${read_args[@]}" -ru "$fd" path; do
 
     if (( create_package )); then
         if (( chroot )); then
-            PKGDEST="$var_tmp" aur chroot "${chroot_args[@]}" --build "${chroot_build_args[@]}"
+            env PKGDEST="$var_tmp" LOGDEST="${LOGDEST:-$PWD}" "${makepkg_env[@]}" \
+                aur chroot "${chroot_args[@]}" --build "${chroot_build_args[@]}"
         else
             #shellcheck disable=SC2086
-            PKGDEST="$var_tmp" LOGDEST="${LOGDEST:-$PWD}" \
+            env PKGDEST="$var_tmp" LOGDEST="${LOGDEST:-$PWD}" "${makepkg_env[@]}" \
                 ${AUR_MAKEPKG:-makepkg} "${makepkg_common_args[@]}" "${makepkg_args[@]}"
         fi
 

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -6,8 +6,10 @@ argv0=sync
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 XDG_STATE_HOME=${XDG_STATE_HOME:-$HOME/.local/state}
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 AURDEST=${AURDEST:-$XDG_CACHE_HOME/aurutils/$argv0}
 AUR_SYNC_USE_NINJA=${AUR_SYNC_USE_NINJA:-0}
+AUR_SYNC_GNUPGHOME=${AUR_SYNC_GNUPGHOME:-$XDG_DATA_HOME/aurutils/$argv0/gnupg}
 PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 # Avoid CDPATH screwing with cd (#1047)
@@ -18,7 +20,7 @@ build_args=(--syncdeps) build_repo_args=()
 depends_args=() view_args=() filter_args=() fetch_args=() graph_args=() reparse_args=()
 
 # default options
-build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1
+build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1 auto_key_retrieve=1
 
 # default options (disabled)
 rotate=0 update=0 repo_targets=0 columns=0
@@ -94,11 +96,11 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:' 'remove'
           'provides-from:' 'new' 'prevent-downgrade' 'verify' 'makepkg-args:'
           'format:' 'no-check' 'keep-going:' 'user:' 'rebase' 'reset' 'ff' 'exclude:'
-          'columns' 'prefix' 'save:' 'clean' 'cleanbuild')
+          'columns' 'prefix' 'save:' 'clean' 'cleanbuild' 'no-key-retrieve')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nosync' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
-            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:')
+            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:' 'nokeyretrieve')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
     eval set -- "$opts"
@@ -146,6 +148,8 @@ while true; do
             view=0 ;;
         --noprovides|--no-provides)
             provides=0 ;;
+        --nokeyretrieve|--no-key-retrieve)
+            auto_key_retrieve=0 ;;
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
             repo_p+=("${repo[@]}")
@@ -384,6 +388,28 @@ if (( download )); then
     aur fetch -S "${fetch_args[@]}" --discard - < "$tmp"/queue >&2
 else
     xargs -a "$tmp"/queue stat >/dev/null || exit 2 # ensure all directories are available
+fi
+
+if (( auto_key_retrieve )); then
+    # shellcheck disable=SC2174
+    mkdir -pm 0700 -- "$AUR_SYNC_GNUPGHOME"
+    declare -A keys_uniq
+
+    # Retrieve unique set of gpg keys to be imported
+    while IFS= read -r path; do
+        mapfile -t keys < <(pacini "$path"/.SRCINFO 'validpgpkeys')
+
+        for key in "${keys[@]}"; do
+            keys_uniq[$key]=1
+        done
+    done < "$tmp"/queue
+
+    if (( ${#keys_uniq[@]} )); then
+        printf >&2 '%s: importing key %s\n' "${!keys_uniq[@]}"
+        GNUPGHOME="$AUR_SYNC_GNUPGHOME" gpg --recv-keys "${!keys_uniq[@]}" >&2
+    fi
+    # Pass on verified keys to makepkg
+    build_args+=(--makepkg-gnupghome="$AUR_SYNC_GNUPGHOME")
 fi
 
 # Verify dependency tree (#20)

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -397,17 +397,20 @@ if (( auto_key_retrieve )); then
 
     # Retrieve unique set of gpg keys to be imported
     while IFS= read -r path; do
-        mapfile -t keys < <(pacini "$path"/.SRCINFO 'validpgpkeys')
+        if [[ -f $path/.SRCINFO ]]; then
+            mapfile -t keys < <(pacini "$path"/.SRCINFO 'validpgpkeys')
 
-        for key in "${keys[@]}"; do
-            keys_uniq[$key]=1
-        done
+            for key in "${keys[@]}"; do
+                keys_uniq[$key]=1
+            done
+        fi
     done < "$tmp"/queue
 
     if (( ${#keys_uniq[@]} )); then
         printf >&2 '%s: importing key %s\n' "${!keys_uniq[@]}"
         GNUPGHOME="$AUR_SYNC_GNUPGHOME" gpg --recv-keys "${!keys_uniq[@]}" >&2
     fi
+
     # Pass on verified keys to makepkg
     build_args+=(--makepkg-gnupghome="$AUR_SYNC_GNUPGHOME")
 fi

--- a/lib/aur-sync
+++ b/lib/aur-sync
@@ -20,10 +20,10 @@ build_args=(--syncdeps) build_repo_args=()
 depends_args=() view_args=() filter_args=() fetch_args=() graph_args=() reparse_args=()
 
 # default options
-build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1 auto_key_retrieve=1
+build=1 chkver_depth=2 download=1 view=1 provides=1 graph=1 keep_going=1
 
 # default options (disabled)
-rotate=0 update=0 repo_targets=0 columns=0
+rotate=0 update=0 repo_targets=0 columns=0 auto_key_retrieve=0
 
 args_csv() {
     # shellcheck disable=SC2155
@@ -88,7 +88,7 @@ if (( UID == 0 )) && [[ ! -v AUR_ASROOT ]]; then
 fi
 
 # option parsing
-opt_short='d:D:k:U:ACcfLnorRSTuv'
+opt_short='d:D:k:U:ACcfKLnorRSTuv'
 opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'makepkg-conf:' 'pacman-conf:' 'chroot' 'continue' 'force' 'ignore-arch'
           'log' 'no-confirm' 'no-ver' 'no-graph' 'no-sync' 'no-ver-argv' 'no-view'
@@ -96,11 +96,11 @@ opt_long=('bind:' 'bind-rw:' 'database:' 'directory:' 'ignore:' 'root:'
           'rebuild' 'rebuild-tree' 'rebuild-all' 'ignore-file:' 'remove'
           'provides-from:' 'new' 'prevent-downgrade' 'verify' 'makepkg-args:'
           'format:' 'no-check' 'keep-going:' 'user:' 'rebase' 'reset' 'ff' 'exclude:'
-          'columns' 'prefix' 'save:' 'clean' 'cleanbuild' 'no-key-retrieve')
+          'columns' 'prefix' 'save:' 'clean' 'cleanbuild' 'auto-key-retrieve')
 opt_hidden=('dump-options' 'allan' 'ignorearch' 'ignorefile:' 'noconfirm'
             'nover' 'nograph' 'nosync' 'nover-argv' 'noview' 'noprovides' 'nobuild'
             'rebuildall' 'rebuildtree' 'rm-deps' 'gpg-sign' 'margs:' 'nocheck'
-            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:' 'nokeyretrieve')
+            'no-checkdepends' 'nocheckdepends' 'optdepends' 'repo:' 'autokeyretrieve')
 
 if opts=$(getopt -o "$opt_short" -l "$(args_csv "${opt_long[@]}" "${opt_hidden[@]}")" -n "$argv0" -- "$@"); then
     eval set -- "$opts"
@@ -148,8 +148,8 @@ while true; do
             view=0 ;;
         --noprovides|--no-provides)
             provides=0 ;;
-        --nokeyretrieve|--no-key-retrieve)
-            auto_key_retrieve=0 ;;
+        -K|--auto-key-retrieve|--autokeyretrieve)
+            auto_key_retrieve=1 ;;
         --provides-from)
             shift; IFS=, read -a repo -r <<< "$1"
             repo_p+=("${repo[@]}")

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -5,9 +5,9 @@
   + propagate `LOGDEST` to `aur-chroot`
 
 * `aur-sync`
- + retrieve PGP keys to `AUR_SYNC_GNUPGHOME` keyring
-    - keyring defaults to `$XDG_DATA_HOME/aurutils/sync/gnupg`
-    - disable with `--no-key-retrieve`
+ + add `--auto-key-retrieve`
+   - retrieve PGP keys to `AUR_SYNC_GNUPGHOME` keyring
+   - keyring defaults to `$XDG_DATA_HOME/aurutils/sync/gnupg`
 
 ## 20.1
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -4,6 +4,11 @@
   + add `AUR_MAKEPKG_GNUPGHOME`, `--makepkg-gnupghome`
   + propagate `LOGDEST` to `aur-chroot`
 
+* `aur-sync`
+ + retrieve PGP keys to `AUR_SYNC_GNUPGHOME` keyring
+    - keyring defaults to `$XDG_DATA_HOME/aurutils/sync/gnupg`
+    - disable with `--no-key-retrieve`
+
 ## 20.1
 
 * `aur-chroot`

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,9 @@
+## 21
+
+* `aur-build`
+  + add `AUR_MAKEPKG_GNUPGHOME`, `--makepkg-gnupghome`
+  + propagate `LOGDEST` to `aur-chroot`
+
 ## 20.1
 
 * `aur-chroot`

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -152,6 +152,15 @@ operations. For chroot builds, the file is also used inside the container.
 .RB ( makepkg " " \-\-config ", " aur\-chroot " " \-\-makepkg\-conf ).
 .
 .TP
+.BI \-\-makepkg\-gnupghome= PATH
+The
+.BR gpg (1)
+home directory used with
+.BR makepkg (8)
+or
+.BR aur\-chroot (1).
+.
+.TP
 .BI \-\-pacman\-conf= FILE
 The file used for retrieving local repositories
 .RB ( aur\-repo " " \-\-config ).
@@ -320,6 +329,17 @@ options if
 .B aur\-build \-\-pkgver
 is used.
 .
+.TP
+.B AUR_MAKEPKG_GNUPGHOME
+Directory where the 
+.BR gpg (1)
+keyring for usage with
+.BR makepkg (8)
+or
+.BR aur\-chroot (1)
+is stored. This variable takes precedence over
+.BR GNUPGHOME .
+.
 .B AUR_BUILD_PKGLIST
 The command used to check for built packages in the local
 repository. Defaults to
@@ -337,7 +357,7 @@ The command used to sign packages. The arguments
 and
 .BR \-\-no\-armor
 must be supported by this command.
-
+.
 .TP
 .B AUR_REPO_ADD
 The command used to update the local repository. Any

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -257,9 +257,14 @@ Do not wait for user input when installing or removing build dependencies.
 Print target packages and their paths instead of building them.
 .
 .TP
-.BR \-\-nokeyretrieve ", " \-\-no\-key\-retrieve
-Do not automatically import PGP keys to
-.BR AUR_SYNC_GNUPGHOME .
+.BR \-K ", " \-\-autokeyretrieve ", " \-\-auto\-key\-retrieve
+Automatically import PGP keys to
+.BR AUR_SYNC_GNUPGHOME ,
+based on the
+.B validpgpkeys
+array in
+.B .SRCINFO
+files.
 .
 .TP
 .BR \-C ", " \-\-clean

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -257,6 +257,11 @@ Do not wait for user input when installing or removing build dependencies.
 Print target packages and their paths instead of building them.
 .
 .TP
+.BR \-\-nokeyretrieve ", " \-\-no\-key\-retrieve
+Do not automatically import PGP keys to
+.BR AUR_SYNC_GNUPGHOME .
+.
+.TP
 .BR \-C ", " \-\-clean
 Clean up leftover work files and directoreis after a successful build.
 .RB ( "aur build \-C" )
@@ -350,6 +355,13 @@ or
 .BR \-\-ff ,
 it is advised to set a persistent path such as
 .IR /home/aurpkgs .
+.
+.TP
+.B AUR_SYNC_GNUPGHOME
+The path where
+.B validpgpkeys
+are imported. Defaults to
+.IR XDG_DATA_HOME/aurutils/sync/gnupg .
 .
 .TP
 .B AUR_SYNC_USE_NINJA


### PR DESCRIPTION
This uses a separate gpg keyring for signature verification with `makepkg(8)`. Since this will not affect the default keyring, the behavior is enabled by default.

Closes #1129.