### PR TITLE
chroot: unbreak `--path`

### DIFF
--- a/lib/aur-chroot
+++ b/lib/aur-chroot
@@ -186,7 +186,7 @@ fi
 
 # Print paths to container and used makepkg/pacman paths. This does
 # not require a priorly created container.
-if (( status )) || ! (( update + build + create )); then
+if (( status )) || ! (( update + build + create + print_path )); then
     printf 'chroot:%s\npacman:%s\nmakepkg:%s\n' "$directory" "$pacman_conf" "$makepkg_conf"
     exit 0
 fi


### PR DESCRIPTION
Avoid triggering the implied `--status` when `--path` is given.

Fixes: 3c282892 ("chroot: make --status default if no modes are specified")