### PR TITLE
`build`: do not define `LOGDEST` explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ETCDIR ?= /etc
 AURUTILS_LIB_DIR ?= $(LIBDIR)/$(PROGNM)
 AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
-AURUTILS_VERSION := 20.5
+AURUTILS_VERSION := 20.5.1
 endif
 AURUTILS_LIB = $(shell find lib/ -name 'aur-*')
 

--- a/lib/pacman/aur-build
+++ b/lib/pacman/aur-build
@@ -407,11 +407,11 @@ while IFS= read "${read_args[@]}" -ru "$fd" path; do
 
     if (( create_package )); then
         if (( chroot )); then
-            env PKGDEST="$var_tmp" LOGDEST="${LOGDEST:-$PWD}" "${makepkg_env[@]}" \
+            env PKGDEST="$var_tmp" "${makepkg_env[@]}" \
                 aur chroot "${chroot_args[@]}" --build "${chroot_build_args[@]}"
         else
             #shellcheck disable=SC2086
-            env PKGDEST="$var_tmp" LOGDEST="${LOGDEST:-$PWD}" "${makepkg_env[@]}" \
+            env PKGDEST="$var_tmp" "${makepkg_env[@]}" \
                 ${AUR_MAKEPKG:-makepkg} "${makepkg_common_args[@]}" "${makepkg_args[@]}"
         fi
 

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -1,3 +1,8 @@
+## 20.5.1
+
+* `aur-build`
+  + do not define `LOGDEST` explicitly
+
 ## 20.5
 
 * `aur-chroot`


### PR DESCRIPTION
This was introduced in commit 26409db to avoid log files ending up in /var/tmp. However, PKGDEST ostensibly has no effect on LOGDEST in later pacman versions.

https://github.com/aurutils/aurutils/issues/1196#issuecomment-2926600742