### PR TITLE
Fix bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AURUTILS_VERSION ?= $(shell git describe --tags || true)
 ifeq ($(AURUTILS_VERSION),)
 AURUTILS_VERSION := 20.5.1
 endif
-AURUTILS_LIB = $(shell find lib/ -name 'aur-*')
+AURUTILS_LIB := $(shell find lib/ -type f -name 'aur-*')
 
 .PHONY: shellcheck install build completion aur
 

--- a/completions/Makefile
+++ b/completions/Makefile
@@ -8,9 +8,11 @@ ZSH_SITE_FUNCTIONS = \
 	zsh/_aur_packages \
 	zsh/_aur_repositories
 
+AURUTILS_LIB := $(shell find ../lib -type f -name 'aur-*')
+
 bash: bash/aur
 
-bash/aur: bash/aurutils.in ../lib/*
+bash/aur: bash/aurutils.in $(AURUTILS_LIB)
 	bash $< >$@
 
 install-bash: bash/aur

--- a/completions/command_opts.sh
+++ b/completions/command_opts.sh
@@ -8,7 +8,7 @@ default_opts() {
     local cmd corecommands=() opts=()
 
     for cmd in "${have_optdump[@]}"; do
-        mapfile -t opts < <(bash "../lib/aur-${cmd}" --dump-options | LC_ALL=C sort)
+        mapfile -t opts < <(find ../lib -type f -name "aur-$cmd" -exec bash -- {} --dump-options ';' | LC_ALL=C sort)
         corecommands+=("default_cmds[${cmd}]='${opts[*]}'")
     done
 


### PR DESCRIPTION
Got this error while building the latest PKGBUILD from aur:

```
==> Validating source files with sha256sums...
    aurutils-20.5.tar.gz ... Passed
==> Extracting sources...
  -> Extracting aurutils-20.5.tar.gz with bsdtar
==> Starting build()...
sed -e 's|AURUTILS_LIB_DIR|/usr/lib/aurutils|' \
    -e 's|AURUTILS_VERSION|20.5|' aur.in >aur
make[1]: Entering directory '/home/user/src/pkgbuilds/aurutils/src/aurutils-20.5/completions'
bash bash/aurutils.in >bash/aur
bash: ../lib/aur-build: No such file or directory
bash: ../lib/aur-chroot: No such file or directory
bash: ../lib/aur-fetch: No such file or directory
bash: ../lib/aur-pkglist: No such file or directory
bash: ../lib/aur-repo: No such file or directory
bash: ../lib/aur-repo-filter: No such file or directory
bash: ../lib/aur-srcver: No such file or directory
bash: ../lib/aur-vercmp: No such file or directory
bash: ../lib/aur-view: No such file or directory
make[1]: Nothing to be done for 'zsh'.
make[1]: Leaving directory '/home/user/src/pkgbuilds/aurutils/src/aurutils-20.5/completions'
```
