### PR TITLE
Concretize what aurutils sees as a positive value

### DIFF
--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -771,7 +771,7 @@ retrieved with the `--path` option, e.g for use with `makepkg --config`.
 ## 7
 
 This release adds optional support for the `ninja` build system. If the
-`AUR_SYNC_USE_NINJA` environment variable is set to a positive value,
+`AUR_SYNC_USE_NINJA` environment variable is set to a positive integer value,
 `aur-sync` will generate `build.ninja` where each target has an `aur-build`
 command-line. This allows to continue building a series of packages when
 several failed, with the maximum of failed targets controlled by the `-k` /

--- a/man1/aur-fetch.1
+++ b/man1/aur-fetch.1
@@ -236,7 +236,7 @@ The default branch of an AUR mirror. Defaults to
 .
 .TP
 .B AUR_FETCH_USE_MIRROR
-If this variable is set to a positive value, clone repositories from an AUR
+If this variable is set to a positive integer value, clone repositories from an AUR
 mirror instead of
 .BR AUR_LOCATION .
 Upstream changes are merged from

--- a/man1/aur-sync.1
+++ b/man1/aur-sync.1
@@ -378,7 +378,7 @@ are imported. Defaults to
 .
 .TP
 .B AUR_SYNC_USE_NINJA
-When set to a positive value, run
+When set to a positive integer value, run
 .B aur\-build
 command-lines with
 .BR ninja .


### PR DESCRIPTION
With the current wording users might expect aurutils to accept values like `true`. This change concretizes it to integers.