### PR TITLE
Add missing section header declaration to aur-build man page

### DIFF
--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -366,6 +366,7 @@ options (see the
 .B repo\-add options
 section) forwarded must be supported by this command.
 .
+.TP
 .B AUR_PACMAN_AUTH
 A command prefix for running
 .BR pacman (8)


### PR DESCRIPTION
Without this, the formatting of the `AUR_PACMAN_BUILD` environment variable was incorrect.