### PR TITLE
`build`: add `--pool`

### DIFF
--- a/lib/pacman/aur-build
+++ b/lib/pacman/aur-build
@@ -78,7 +78,7 @@ opt_long=('arg-file:' 'chroot' 'database:' 'force' 'root:' 'sign' 'gpg-sign'
           'makepkg-conf:' 'bind:' 'bind-rw:' 'prevent-downgrade' 'temp'
           'syncdeps' 'clean' 'namcap' 'checkpkg' 'makepkg-args:' 'user:'
           'margs:' 'buildscript:' 'null' 'dbext:' 'cleanbuild' 'cargs:'
-          'makechrootpkg-args:' 'makepkg-gnupghome:')
+          'makechrootpkg-args:' 'makepkg-gnupghome:' 'pool:')
 opt_hidden=('dump-options' 'ignorearch' 'noconfirm' 'nocheck' 'nosync' 'repo:'
             'results:' 'results-append:' 'status')
 
@@ -88,7 +88,7 @@ else
     usage
 fi
 
-unset buildscript db_ext db_name db_path db_root makepkg_conf pacman_conf queue results_file
+unset buildscript db_ext db_name db_path db_pool db_root makepkg_conf pacman_conf queue results_file
 while true; do
     case "$1" in
         # build options
@@ -122,6 +122,8 @@ while true; do
         --root)
             shift; db_root=$1
             repo_args+=(--root "$1") ;;
+        --pool)
+            shift; db_pool=$1 ;;
         -S|--sign|--gpg-sign)
             sign_pkg=1; repo_add_args+=(-s) ;;
         # chroot options
@@ -441,7 +443,15 @@ while IFS= read "${read_args[@]}" -ru "$fd" path; do
     done
 
     if (( create_package )); then
-        mv -f "${siglist[@]}" "${pkglist[@]}" "$db_root"
+        # pkglist/siglist contain basename
+        if [[ $db_root != "$db_pool" ]]; then
+            mv -f "${siglist[@]}" "${pkglist[@]}" "$db_pool"
+
+            # Absolute links for packages in pool (repose --pool)
+            ln -t "$db_root" -s -- "${pkglist[@]/#/$db_pool/}" "${siglist[@]/#/$db_pool/}"
+        else
+            mv -f "${siglist[@]}" "${pkglist[@]}" "$db_root"
+        fi
 
         if [[ -v results_file ]]; then
             printf "build:file://$db_root/%s\n" "${pkglist[@]}" | tee -a "$results_file" >/dev/null

--- a/makepkg/aurutils.changelog
+++ b/makepkg/aurutils.changelog
@@ -2,8 +2,9 @@
 
 * `aur-build`
   + move local repository sync to `build--sync`
-  + implement file-based locking (`makepkg` implementation)
-  + implement `pactrans` upgrade
+    - implement file-based locking (`makepkg` implementation)
+    - implement `pactrans` upgrade
+  + add `--pool`
 
 * `aur-fetch`
   + support mixed url and pkgbase names (#1104)

--- a/man1/aur-build.1
+++ b/man1/aur-build.1
@@ -58,8 +58,8 @@ database.
 The root directory for the repository. The
 .I root
 is the location for the pacman database
-.RI ( foo.db ),
-built packages, and secondary files such as the files database
+.RI ( foo.db )
+and secondary files such as the files database
 .RI ( foo.files ).
 This defaults to the value of the
 .B Server
@@ -74,6 +74,17 @@ is used for
 .BR pacman (8)
 sync operations regardless of this setting. See also
 .BR \-\-no\-sync .
+.
+.TP
+.BI \-\-pool= DIR
+The pool directory for the repository. The
+.I pool
+is the location for built packages.
+If this value differs from the repository root (see
+.BR \-\-root )
+symbolic links are maintained, and the root contains links to
+all packages referenced by the repository. This requires a file
+system that supports symbolic links.
 .
 .TP
 .BR \-f ", " \-\-force


### PR DESCRIPTION
This matches `repose --pool` as discussed in #1213. I'm not entirely sure on use-cases for this option, but the implementation is short enough.

The ugly part is file systems that don't support symbolic links. This could be checked beforehand with something like:
```bash
support_symlink() {
  env -C "$1" perl -e 'print eval {symlink("",""); 1};'
}

if [[ $db_root != "$db_pool" ]] && (( ! $(support_symlink "$db_root") )); then
    printf 'warning: --pool: repository root %s does not support symlinks' "$db_pool"
    # either 1. reset $db_pool to $db_root 2. exit with an error
fi
```